### PR TITLE
Add fetch_investor_token

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -8,8 +8,8 @@ config :belay_api_client,
   api_url: System.get_env("BELAY_API_URL") || "http://localhost:4000",
   offerings_host: System.get_env("BELAY_API_OFFERINGS") || "ws://localhost:4000",
   partner_id: System.get_env("BELAY_API_PARTNER_ID") || "belay_alpaca",
-  client_id: System.get_env("BELAY_API_CLIENT_ID") || System.fetch_env!("BELAY_ALPACA__AUTH0__CLIENT_ID"),
-  client_secret: System.fetch_env!("BELAY_API_CLIENT_SECRET") || System.fetch_env!("BELAY_ALPACA__AUTH0__CLIENT_SECRET")
+  client_id: System.fetch_env!("BELAY_ALPACA__AUTH0__CLIENT_ID"),
+  client_secret: System.fetch_env!("BELAY_ALPACA__AUTH0__CLIENT_SECRET")
 
 config :phoenix, :json_library, Jason
 

--- a/envrc.template
+++ b/envrc.template
@@ -1,0 +1,7 @@
+export BELAY_ALPACA__AUTH0__CLIENT_ID=???
+export BELAY_ALPACA__AUTH0__CLIENT_SECRET=???
+
+# Defaults
+export BELAY_API_URL=http://localhost:4000
+export BELAY_API_OFFERINGS=ws://localhost:4000
+export BELAY_API_PARTNER_ID=belay_alpaca

--- a/lib/belay_api_client.ex
+++ b/lib/belay_api_client.ex
@@ -62,6 +62,16 @@ defmodule BelayApiClient do
   end
 
   @doc """
+  Fetch an investor token from BelayApi for the given client_id and client_secret.
+  """
+  def fetch_investor_token(client, investor_id) do
+    case(Tesla.get(client, "/api/investors/#{investor_id}/token")) do
+      {:ok, %Tesla.Env{status: 200, body: %{"token" => token}}} -> {:ok, %{token: token}}
+      bad_response -> parse_error(bad_response)
+    end
+  end
+
+  @doc """
   Fetch the investor_id for the given email address
   """
   def fetch_investor_id(%Client{} = client, partner_id, email) do

--- a/lib/belay_api_offerings.ex
+++ b/lib/belay_api_offerings.ex
@@ -75,6 +75,7 @@ defmodule BelayApiOfferings do
       case await_connect(socket) do
         {:ok, socket} ->
           :ets.insert(__MODULE__, {:status, :connected})
+
           Enum.reduce(stock_universe, socket, fn sym, socket ->
             join(socket, "offerings:#{sym}")
           end)


### PR DESCRIPTION
- [x] Adds a call to `fetch_investor_token` so partners/investor-web can determine the eligibility of investors
- [x] Adds envrc template
- [x] Small test cleanup (more accurate test names)