### PR TITLE
Feature/more smoke tests

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -3,3 +3,8 @@ import Config
 config :belay_api_client,
   stock_universe: ["AAPL", "TSLA"],
   ws_url: System.get_env("BELAY_API_WS_URL", "ws://localhost:4000")
+
+config :belay_api_client, Alpaca,
+  base_url: System.fetch_env!("ALPACA_BASE_URL"),
+  key: System.fetch_env!("ALPACA_KEY"),
+  secret: System.fetch_env!("ALPACA_SECRET")

--- a/lib/belay_api_client.ex
+++ b/lib/belay_api_client.ex
@@ -83,17 +83,26 @@ defmodule BelayApiClient do
   end
 
   @doc """
-  Fetch policies for the given investor
+  Fetch all partner policies
   """
-  def fetch_policies(%Client{} = client, investor_id) do
+  def fetch_policies(%Client{} = client) do
     case Tesla.get(client, "/api/policies") do
       {:ok, %Tesla.Env{status: 200, body: policies}} ->
-        policies = Enum.filter(policies, fn policy -> policy["investor_account_id"] == investor_id end)
-
         {:ok, policies}
 
       response ->
         parse_error(response)
+    end
+  end
+
+  @doc """
+  Fetch policies for the given investor
+  """
+  def fetch_policies(%Client{} = client, investor_id) do
+    with {:ok, partner_policies} <- fetch_policies(client) do
+      policies = Enum.filter(partner_policies, fn policy -> policy["investor_account_id"] == investor_id end)
+
+      {:ok, policies}
     end
   end
 

--- a/lib/belay_api_client.ex
+++ b/lib/belay_api_client.ex
@@ -109,7 +109,7 @@ defmodule BelayApiClient do
   @doc """
   Buy a policy for the given investor
   """
-  def buy_policy(%Client{} = client, investor_id, sym, expiration, qty, strike) do
+  def buy_policy(%Client{} = client, investor_id, sym, expiration, qty, strike, purchase_limit_price) do
     policy = %{
       "sym" => sym,
       "expiration" => expiration,
@@ -117,7 +117,7 @@ defmodule BelayApiClient do
       "qty" => qty,
       "strike" => strike,
       "partner_investor_id" => investor_id,
-      "purchase_limit_price" => strike
+      "purchase_limit_price" => purchase_limit_price
     }
 
     case Tesla.post(client, "/api/policies", policy) do

--- a/lib/belay_api_client.ex
+++ b/lib/belay_api_client.ex
@@ -53,7 +53,7 @@ defmodule BelayApiClient do
     url = Application.fetch_env!(:belay_api_client, :api_url)
     client = Tesla.client([{Tesla.Middleware.BaseUrl, url}, Tesla.Middleware.JSON])
 
-    case(Tesla.post(client, "/api/oauth/token", %{client_id: client_id, client_secret: client_secret})) do
+    case Tesla.post(client, "/api/oauth/token", %{client_id: client_id, client_secret: client_secret}) do
       {:ok, %Tesla.Env{status: 200, body: %{"access_token" => access_token, "expires_in" => expires_in}}} ->
         {:commit, %{access_token: access_token, expires_in: expires_in}}
 
@@ -66,7 +66,7 @@ defmodule BelayApiClient do
   Fetch an investor token from BelayApi for the given client_id and client_secret.
   """
   def fetch_investor_token(client, investor_id) do
-    case(Tesla.get(client, "/api/investors/#{investor_id}/token")) do
+    case Tesla.get(client, "/api/investors/#{investor_id}/token") do
       {:ok, %Tesla.Env{status: 200, body: %{"token" => token}}} -> {:ok, %{token: token}}
       bad_response -> parse_error(bad_response)
     end

--- a/test/belay_api_client/belay_api_client_test.exs
+++ b/test/belay_api_client/belay_api_client_test.exs
@@ -253,7 +253,7 @@ defmodule BelayApiClientTest do
       end)
 
       assert {:ok, expected_body} ==
-               BelayApiClient.buy_policy(client, @investor_id, "AAPL", "2023-11-23", 10, 42)
+               BelayApiClient.buy_policy(client, @investor_id, "AAPL", "2023-11-23", 10, 42, 100)
     end
   end
 

--- a/test/integration/belay_api_client_test.exs
+++ b/test/integration/belay_api_client_test.exs
@@ -33,7 +33,7 @@ defmodule Integration.BelayApiClientTest do
 
     test "buy_policy" do
       client = create_real_client()
-      assert {:ok, policy} = BelayApiClient.buy_policy(client, @investor_id, "AAPL", "2023-11-23", 10, 42)
+      assert {:ok, policy} = BelayApiClient.buy_policy(client, @investor_id, "AAPL", "2023-11-23", 10, 42, 100)
 
       assert %{
                "expiration" => "2023-11-23",
@@ -46,7 +46,7 @@ defmodule Integration.BelayApiClientTest do
                "sym" => "AAPL"
              } = policy
 
-      #      assert {:ok, ^policy} = BelayApiClient.buy_policy(@investor_id, "AAPL", "2023-11-23", 10, 42)
+      #      assert {:ok, ^policy} = BelayApiClient.buy_policy(@investor_id, "AAPL", "2023-11-23", 10, 42, 100)
     end
   end
 

--- a/test/smoke/offerings_test.exs
+++ b/test/smoke/offerings_test.exs
@@ -38,6 +38,18 @@ defmodule Smoke.OfferingsTest do
     @describetag :smoke_closed_hours
 
     test "there are no offerings" do
+      opts = Application.get_all_env(:belay_api_client)
+      client_id = Keyword.fetch!(opts, :client_id)
+      client_secret = Keyword.fetch!(opts, :client_secret)
+      host = Keyword.fetch!(opts, :ws_url)
+
+      {:commit, %{access_token: token}} = BelayApiClient.fetch_token(client_id, client_secret)
+
+      start_supervised!({PartnerSocket, test_pid: self(), host: host, token: token, stock_universe: [@sym]})
+
+      expected_topic = "offerings:#{@sym}"
+
+      assert_receive {^expected_topic, :joined, []}
     end
   end
 end

--- a/test/smoke/offerings_test.exs
+++ b/test/smoke/offerings_test.exs
@@ -1,33 +1,43 @@
 defmodule Smoke.OfferingsTest do
   use ExUnit.Case, async: false
   use AssertEventually, timeout: 1000, interval: 5
-  @moduletag :smoke
 
   alias BelayApiClient.PartnerSocket
 
   @sym "AAPL"
 
-  test "connect to server and see that we're getting offerings" do
-    opts = Application.get_all_env(:belay_api_client)
-    client_id = Keyword.fetch!(opts, :client_id)
-    client_secret = Keyword.fetch!(opts, :client_secret)
-    host = Keyword.fetch!(opts, :ws_url)
+  describe "when during market hours" do
+    @describetag :smoke_open_hours
 
-    {:commit, %{access_token: token}} = BelayApiClient.fetch_token(client_id, client_secret)
+    test "connect to server and see that we're getting offerings" do
+      opts = Application.get_all_env(:belay_api_client)
+      client_id = Keyword.fetch!(opts, :client_id)
+      client_secret = Keyword.fetch!(opts, :client_secret)
+      host = Keyword.fetch!(opts, :ws_url)
 
-    start_supervised!({PartnerSocket, test_pid: self(), host: host, token: token, stock_universe: [@sym]})
+      {:commit, %{access_token: token}} = BelayApiClient.fetch_token(client_id, client_secret)
 
-    expected_topic = "offerings:#{@sym}"
+      start_supervised!({PartnerSocket, test_pid: self(), host: host, token: token, stock_universe: [@sym]})
 
-    assert_receive {^expected_topic, :joined, offerings}
+      expected_topic = "offerings:#{@sym}"
 
-    assert %{
-             "expiration" => expiration,
-             "price" => %{"amount" => _price, "currency" => "USD"},
-             "strike" => %{"amount" => _strike, "currency" => "USD"},
-             "sym" => "AAPL"
-           } = hd(offerings)
+      assert_receive {^expected_topic, :joined, offerings}
 
-    assert {:ok, _exp} = Date.from_iso8601(expiration)
+      assert %{
+               "expiration" => expiration,
+               "price" => %{"amount" => _price, "currency" => "USD"},
+               "strike" => %{"amount" => _strike, "currency" => "USD"},
+               "sym" => "AAPL"
+             } = hd(offerings)
+
+      assert {:ok, _exp} = Date.from_iso8601(expiration)
+    end
+  end
+
+  describe "when off market hours" do
+    @describetag :smoke_closed_hours
+
+    test "there are no offerings" do
+    end
   end
 end

--- a/test/smoke/policy_updates_test.exs
+++ b/test/smoke/policy_updates_test.exs
@@ -76,7 +76,7 @@ defmodule Smoke.PolicyUpdatesTest do
   end
 
   defp fetch_investor_id(client) do
-    {:ok, investor_accounts} = Alpaca.get_accounts()
+    {:ok, investor_accounts} = Alpaca.get_active_smoke_accounts()
     {:ok, policies} = BelayApiClient.fetch_policies(client)
 
     policy_investors = Enum.map(policies, & &1.partner_investor_id)

--- a/test/smoke/policy_updates_test.exs
+++ b/test/smoke/policy_updates_test.exs
@@ -5,7 +5,7 @@ defmodule Smoke.PolicyUpdatesTest do
 
   alias BelayApiClient.PartnerSocket
 
-  @investor_id "b6df1a1f-b7d5-479f-9a1f-c79bead97203"
+  @sym "AAPL"
 
   setup _ do
     opts = Application.get_all_env(:belay_api_client)
@@ -15,19 +15,64 @@ defmodule Smoke.PolicyUpdatesTest do
 
     {:commit, %{access_token: token}} = BelayApiClient.fetch_token(client_id, client_secret)
 
-    pid = start_supervised!({PartnerSocket, test_pid: self(), host: host, token: token, stock_universe: ["AAPL"]})
+    pid = start_supervised!({PartnerSocket, test_pid: self(), host: host, token: token, stock_universe: [@sym]})
 
     assert_receive {"policy_updates", :joined, _}
 
     %{token: token, host: host, pid: pid, client_id: client_id, client_secret: client_secret}
   end
 
-  test "foo", acc do
+  test "buy policy, push until activated, then sell some of the stock", acc do
     {:ok, client} = BelayApiClient.client(acc.client_id, acc.client_secret)
 
+    # Fetch a investor that hasn't purchased a policy
+    investor_id = fetch_investor_id(client)
+
+    # Buy 1 share of the stock we are about to get a policy on
+    {:ok, _} = Alpaca.create_order(@sym, "1", investor_id)
+
+    # Fetch first offering
+    assert_receive {"offerings:#{@sym}", :joined, [offering | _]}
+
+    # Translate data types
+    expiration = offering["expiration"]
+    qty = 1.0
+    # FIXME: This shouldn't be necessary, we shouldn't be returning the money map
+    strike = Float.to_string(offering["strike"]["amount"] / 100)
+
     assert {:ok, %{"policy_id" => policy_id}} =
-             BelayApiClient.buy_policy(client, @investor_id, "AAPL", "2023-11-23", 10, 42)
+             BelayApiClient.buy_policy(client, investor_id, @sym, expiration, qty, strike)
 
     assert_receive {"policy_updates", "policy_update:requested", %{"policy_id" => ^policy_id}}
+
+    assert_receive {"policy_updates", "policy_update:activated", %{"policy_id" => ^policy_id}}
+
+    # Fetch the policies owned for @investor_id and make sure we see the new policy there
+    assert {:ok, received_policies} = BelayApiClient.fetch_policies(client, @investor_id)
+    assert Enum.any?(received_policies, fn %{"policy_id" => received_policy_id} -> received_policy_id == policy_id end)
+
+    # FIXME: We need to write a test that sells the stock, and makes sure qty changed gets invoked or doesn't depending on the market
+    # {:ok, _} = Alpaca.create_order(@sym, "-0.5", @investor_id)
+    # if sym price > policy_strike, assert policy qty is the same
+    # if sym price < policy_strike, assert policy qty is policy qty - qty sold
+    # assert_receive {"policy_updates", "policy_update:qty_changed", %{"policy_id" => ^policy_id}}
+  end
+
+  defp fetch_investor_id(client) do
+    {:ok, investor_accounts} = Alpaca.get_accounts()
+    {:ok, policies} = BelayApiClient.fetch_policies(client)
+
+    policy_investors = Enum.map(policies, & &1.partner_investor_id)
+
+    investor_id =
+      investor_accounts
+      |> Enum.reject(fn %{"id" => id} -> id in policy_investors end)
+      |> Enum.random()
+      |> Map.fetch!("id")
+
+    # Queue a new investor account to be created
+    Task.start_link(fn -> Alpaca.create_funded_user() end)
+
+    investor_id
   end
 end

--- a/test/smoke/policy_updates_test.exs
+++ b/test/smoke/policy_updates_test.exs
@@ -60,6 +60,7 @@ defmodule Smoke.PolicyUpdatesTest do
 
       # Fetch the policies owned for investor_id and make sure we see the new policy there
       assert {:ok, received_policies} = BelayApiClient.fetch_policies(client, investor_id)
+
       assert Enum.any?(received_policies, fn %{"policy_id" => received_policy_id} -> received_policy_id == policy_id end)
 
       # FIXME: We need to write a test that sells the stock, and makes sure qty changed gets invoked or doesn't depending on the market
@@ -97,7 +98,8 @@ defmodule Smoke.PolicyUpdatesTest do
       # a policy failure due to the purchase_limit_price being exceeded
       purchase_limit_price = Float.to_string(0.01)
 
-      assert {:ok, %{"policy_id" => policy_id}} = BelayApiClient.buy_policy(client, investor_id, @sym, expiration, qty, strike, purchase_limit_price)
+      assert {:ok, %{"policy_id" => policy_id}} =
+               BelayApiClient.buy_policy(client, investor_id, @sym, expiration, qty, strike, purchase_limit_price)
 
       assert_receive {"policy_updates", "policy_update:requested", %{"policy_id" => ^policy_id}}
 
@@ -105,6 +107,7 @@ defmodule Smoke.PolicyUpdatesTest do
 
       # Fetch the policies owned for investor_id and make sure we see the new policy there
       assert {:ok, received_policies} = BelayApiClient.fetch_policies(client, investor_id)
+
       refute Enum.any?(received_policies, fn %{"policy_id" => received_policy_id} -> received_policy_id == policy_id end)
     end
   end

--- a/test/smoke/policy_updates_test.exs
+++ b/test/smoke/policy_updates_test.exs
@@ -26,7 +26,7 @@ defmodule Smoke.PolicyUpdatesTest do
   describe "when during market hours" do
     @describetag :smoke_open_hours
 
-    test "buy policy and insure activation", context do
+    test "buy policy and ensure activation", context do
       {:ok, client} = BelayApiClient.client(context.client_id, context.client_secret)
 
       # Fetch a investor that hasn't purchased a policy
@@ -103,9 +103,11 @@ defmodule Smoke.PolicyUpdatesTest do
 
       assert_receive {"policy_updates", "policy_update:requested", %{"policy_id" => ^policy_id}}
 
+      # FIXME: We need to add a assert_receive on a policy failed update, our code in belay-api currently does not emit it
+      # assert_receive {"policy_updates", "policy_update:failed", %{"policy_id" => ^policy_id}}
       refute_receive {"policy_updates", "policy_update:activated", %{"policy_id" => ^policy_id}}
 
-      # Fetch the policies owned for investor_id and make sure we see the new policy there
+      # Fetch the policies owned for investor_id and make sure we don't see the new policy there
       assert {:ok, received_policies} = BelayApiClient.fetch_policies(client, investor_id)
 
       refute Enum.any?(received_policies, fn %{"policy_id" => received_policy_id} -> received_policy_id == policy_id end)

--- a/test/support/alpaca.ex
+++ b/test/support/alpaca.ex
@@ -67,7 +67,7 @@ defmodule Alpaca do
            Tesla.post(client, "/v1/accounts/#{account_id}/transfers", %{
              transfer_type: "ach",
              relationship_id: relationship_id,
-             amount: "500.00",
+             amount: "10000.00",
              direction: "INCOMING"
            }) do
       :ok

--- a/test/support/alpaca.ex
+++ b/test/support/alpaca.ex
@@ -1,0 +1,108 @@
+defmodule Alpaca do
+  @moduledoc """
+  A helper module for running basic test helping functions for integration and smoke tests.
+  Note: Not to be used in prod and dev
+  """
+
+  def get_accounts do
+    with {:ok, %Tesla.Env{status: 200, body: body}} <- Tesla.get(client(), "/v1/accounts") do
+      {:ok, body}
+    end
+  end
+
+  def create_funded_user do
+    client = client()
+
+    with {:ok, %Tesla.Env{status: 200, body: %{"id" => account_id}}} <-
+           Tesla.post(client, "/v1/accounts/", %{
+             contact: %{
+               email_address: rand_email(),
+               phone_number: "555-666-7788",
+               street_address: ["20 N San Mateo Dr"],
+               city: "San Mateo",
+               state: "CA",
+               postal_code: "94401",
+               country: "USA"
+             },
+             identity: %{
+               given_name: "John",
+               family_name: "Doe",
+               tax_id: "666-55-4321",
+               tax_id_type: "USA_SSN",
+               date_of_birth: "1990-01-01",
+               country_of_tax_residence: "USA",
+               funding_source: ["employment_income"]
+             },
+             disclosures: %{
+               is_control_person: false,
+               is_affiliated_exchange_or_finra: true,
+               is_politically_exposed: false,
+               immediate_family_exposed: false
+             },
+             agreements: [
+               %{
+                 agreement: "customer_agreement",
+                 signed_at: "2020-09-11T18:13:44Z",
+                 ip_address: "185.13.21.99",
+                 revision: "19.2022.02"
+               },
+               %{
+                 agreement: "crypto_agreement",
+                 signed_at: "2020-09-11T18:13:44Z",
+                 ip_address: "185.13.21.99",
+                 revision: "04.2021.10"
+               }
+             ]
+           }),
+           {:ok, %Tesla.Env{status: 200, body: %{"id" => relationship_id}}} <-
+            Tesla.post(client, "/v1/accounts/#{account_id}/ach_relationships", %{
+              account_owner_name: "Awesome Alpaca",
+              bank_account_type: "CHECKING",
+              bank_account_number: "32131231abc",
+              bank_routing_number: "121000358",
+              nickname: "Bank of America Checking"
+            }),
+          {:ok, _} <-
+            Tesla.post(client, "/v1/accounts/#{account_id}/transfers", %{
+              transfer_type: "ach",
+              relationship_id: relationship_id,
+              amount: "500.00",
+              direction: "INCOMING"
+            })do
+      :ok
+    end
+  end
+
+  def create_order(sym, qty, partner_investor_id)
+      when is_binary(sym) and is_binary(qty) and is_binary(partner_investor_id) do
+    with {:ok, %Tesla.Env{status: 200, body: body}} <-
+           Tesla.post(client(), "/v1/trading/accounts/#{partner_investor_id}/orders", %{
+             symbol: sym,
+             qty: qty,
+             side: "buy",
+             type: "market",
+             time_in_force: "gtc"
+           }) do
+      {:ok, body}
+    end
+  end
+
+  def close_account(investor_id) do
+    with {:ok, %Tesla.Env{status: 204, body: body}} <- Tesla.post(client(), "/v1/accounts/#{investor_id}/actions/close", %{}) do
+      {:ok, body}
+    end
+  end
+
+  defp client do
+    [base_url: base_url, key: key, secret: secret] = Application.fetch_env!(:belay_api_client, Alpaca)
+    access_token = Base.encode64("#{key}:#{secret}")
+
+    Tesla.client([
+      {Tesla.Middleware.BaseUrl, base_url},
+      Tesla.Middleware.JSON,
+      {Tesla.Middleware.Headers, [{"Authorization", "Basic #{access_token}"}]}
+    ])
+  end
+
+  defp rand_email, do: "smoke_test_email#{System.unique_integer([:positive])}@email.com"
+end

--- a/test/support/alpaca.ex
+++ b/test/support/alpaca.ex
@@ -4,8 +4,9 @@ defmodule Alpaca do
   Note: Not to be used in prod and dev
   """
 
-  def get_accounts do
-    with {:ok, %Tesla.Env{status: 200, body: body}} <- Tesla.get(client(), "/v1/accounts") do
+  def get_active_smoke_accounts do
+    with {:ok, %Tesla.Env{status: 200, body: body}} <-
+           Tesla.get(client(), "/v1/accounts?status=ACTIVE&query=smoke_test") do
       {:ok, body}
     end
   end
@@ -54,21 +55,21 @@ defmodule Alpaca do
                }
              ]
            }),
-           {:ok, %Tesla.Env{status: 200, body: %{"id" => relationship_id}}} <-
-            Tesla.post(client, "/v1/accounts/#{account_id}/ach_relationships", %{
-              account_owner_name: "Awesome Alpaca",
-              bank_account_type: "CHECKING",
-              bank_account_number: "32131231abc",
-              bank_routing_number: "121000358",
-              nickname: "Bank of America Checking"
-            }),
-          {:ok, _} <-
-            Tesla.post(client, "/v1/accounts/#{account_id}/transfers", %{
-              transfer_type: "ach",
-              relationship_id: relationship_id,
-              amount: "500.00",
-              direction: "INCOMING"
-            })do
+         {:ok, %Tesla.Env{status: 200, body: %{"id" => relationship_id}}} <-
+           Tesla.post(client, "/v1/accounts/#{account_id}/ach_relationships", %{
+             account_owner_name: "Awesome Alpaca",
+             bank_account_type: "CHECKING",
+             bank_account_number: "32131231abc",
+             bank_routing_number: "121000358",
+             nickname: "Bank of America Checking"
+           }),
+         {:ok, _} <-
+           Tesla.post(client, "/v1/accounts/#{account_id}/transfers", %{
+             transfer_type: "ach",
+             relationship_id: relationship_id,
+             amount: "500.00",
+             direction: "INCOMING"
+           }) do
       :ok
     end
   end
@@ -88,7 +89,8 @@ defmodule Alpaca do
   end
 
   def close_account(investor_id) do
-    with {:ok, %Tesla.Env{status: 204, body: body}} <- Tesla.post(client(), "/v1/accounts/#{investor_id}/actions/close", %{}) do
+    with {:ok, %Tesla.Env{status: 204, body: body}} <-
+           Tesla.post(client(), "/v1/accounts/#{investor_id}/actions/close", %{}) do
       {:ok, body}
     end
   end
@@ -104,5 +106,5 @@ defmodule Alpaca do
     ])
   end
 
-  defp rand_email, do: "smoke_test_email#{System.unique_integer([:positive])}@email.com"
+  defp rand_email, do: "smoke_test_email#{UUID.uuid4(:hex)}@email.com"
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -6,10 +6,10 @@ is_smoke = :smoke in ExUnit.configuration()[:include]
 
 cond do
   is_smoke and Time.after?(current_time, ~T[14:30:00]) and Time.before?(current_time, ~T[21:00:00]) ->
-    ExUnit.start(include: [smoke_open_hours: true])
+    ExUnit.start(include: [smoke_open_hours: true], exclude: [integration: true, smoke_closed_hours: true])
 
   is_smoke ->
-    ExUnit.start(include: [smoke_closed_hours: true])
+    ExUnit.start(include: [smoke_closed_hours: true], exclude: [integration: true, smoke_open_hours: true])
 
   true ->
     ExUnit.start(exclude: [integration: true, smoke_open_hours: true, smoke_closed_hours: true])

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,4 +1,16 @@
 # Increase assert_receive timeout for all tests since smoke and integration tests may take longer
 ExUnit.configure(assert_receive_timeout: 5_000)
 
-ExUnit.start(exclude: [integration: true, smoke: true])
+current_time = Time.utc_now()
+is_smoke = :smoke in ExUnit.configuration()[:include]
+
+cond do
+  is_smoke and Time.after?(current_time, ~T[14:30:00]) and Time.before?(current_time, ~T[21:00:00]) ->
+    ExUnit.start(include: [smoke_open_hours: true])
+
+  is_smoke ->
+    ExUnit.start(include: [smoke_closed_hours: true])
+
+  true ->
+    ExUnit.start(exclude: [integration: true, smoke_open_hours: true, smoke_closed_hours: true])
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,4 +1,4 @@
 # Increase assert_receive timeout for all tests since smoke and integration tests may take longer
-ExUnit.configure(assert_receive_timeout: 1_000)
+ExUnit.configure(assert_receive_timeout: 5_000)
 
 ExUnit.start(exclude: [integration: true, smoke: true])


### PR DESCRIPTION
- Added ability for test_helper to understand whether the market is open or closed in a naive way to allow for different tests to be hit
- Added some Alpaca support functionality to add funded investors, create_orders, and close accounts to setup test conditions
- Added more smoke tests or added more to existing ones