### PR TITLE
Reduce belay api token calls made

### DIFF
--- a/test/smoke/offerings_test.exs
+++ b/test/smoke/offerings_test.exs
@@ -6,7 +6,7 @@ defmodule Smoke.OfferingsTest do
 
   @sym "AAPL"
 
-  setup do
+  setup_all _ do
     opts = Application.get_all_env(:belay_api_client)
     client_id = Keyword.fetch!(opts, :client_id)
     client_secret = Keyword.fetch!(opts, :client_secret)
@@ -14,6 +14,10 @@ defmodule Smoke.OfferingsTest do
 
     {:ok, %{access_token: token}} = BelayApiClient.fetch_token(client_id, client_secret)
 
+    %{token: token, host: host}
+  end
+
+  setup %{token: token, host: host} do
     start_supervised!({PartnerSocket, test_pid: self(), host: host, token: token, stock_universe: [@sym]})
 
     :ok

--- a/test/smoke/policy_updates_test.exs
+++ b/test/smoke/policy_updates_test.exs
@@ -8,7 +8,7 @@ defmodule Smoke.PolicyUpdatesTest do
 
   @sym "AAPL"
 
-  setup _ do
+  setup_all _ do
     opts = Application.get_all_env(:belay_api_client)
     client_id = Keyword.fetch!(opts, :client_id)
     client_secret = Keyword.fetch!(opts, :client_secret)
@@ -16,11 +16,15 @@ defmodule Smoke.PolicyUpdatesTest do
 
     {:ok, %{access_token: token}} = BelayApiClient.fetch_token(client_id, client_secret)
 
-    pid = start_supervised!({PartnerSocket, test_pid: self(), host: host, token: token, stock_universe: [@sym]})
+    %{token: token, host: host}
+  end
+
+  setup %{token: token, host: host} do
+    start_supervised!({PartnerSocket, test_pid: self(), host: host, token: token, stock_universe: [@sym]})
 
     assert_receive {"policy_updates", :joined, _}
 
-    %{token: token, host: host, pid: pid, client_id: client_id, client_secret: client_secret}
+    :ok
   end
 
   describe "when during market hours" do


### PR DESCRIPTION
Small improvement to only grab an access token once per test file, next step might be to grab one for a whole test run.