### PR TITLE
Better logging

### DIFF
--- a/lib/belay_api_client.ex
+++ b/lib/belay_api_client.ex
@@ -5,6 +5,8 @@ defmodule BelayApiClient do
   alias Decimal
   alias Tesla.Client
 
+  require Logger
+
   @doc """
   Create a Tesla client for calls against BelayApi for the given client_id and client_secret
 
@@ -152,5 +154,9 @@ defmodule BelayApiClient do
     do: {:error, %{status: status, error: body["error"]}}
 
   defp parse_error({_, %Tesla.Env{status: status}}), do: {:error, %{status: status}}
-  defp parse_error(_), do: {:error, :unknown}
+  defp parse_error(reason) do
+    Logger.error("[BelayApiClient] Unexpected result", reason: reason)
+
+    {:error, :unknown}
+  end
 end


### PR DESCRIPTION
The Belay API Client currently swallows any unexpected results coming from the API, which is making debugging harder. We can see the errors happening, but our reason is just `:unknown`. This allows the api client to fire a logger error on unexpected results from belay, which should allow us to debug API calls easier.