### PR TITLE
Add public_client/0 and use it for our public endpoints

### DIFF
--- a/test/belay_api_client/belay_api_client_test.exs
+++ b/test/belay_api_client/belay_api_client_test.exs
@@ -305,9 +305,7 @@ defmodule BelayApiClientTest do
   end
 
   describe "fetch_market_clock" do
-    setup :create_client
-
-    test "returns market clock", %{bypass: bypass, client: client} do
+    test "returns market clock", %{bypass: bypass} do
       expected_body = %{"is_open" => true, "opens_in" => 0}
 
       Bypass.expect_once(bypass, "GET", "/api/market/clock", fn conn ->
@@ -316,14 +314,12 @@ defmodule BelayApiClientTest do
         |> Plug.Conn.resp(200, Jason.encode!(expected_body))
       end)
 
-      assert {:ok, %{is_open: true, opens_in: 0}} == BelayApiClient.fetch_market_clock(client)
+      assert {:ok, %{is_open: true, opens_in: 0}} == BelayApiClient.fetch_market_clock()
     end
   end
 
   describe "fetch_market_stock_universe" do
-    setup :create_client
-
-    test "returns market stock universe", %{bypass: bypass, client: client} do
+    test "returns market stock universe", %{bypass: bypass} do
       expected_stock_universe = ["AAPL", "TSLA", "MSFT"]
       expected_body = %{"stock_universe" => expected_stock_universe}
 
@@ -333,7 +329,7 @@ defmodule BelayApiClientTest do
         |> Plug.Conn.resp(200, Jason.encode!(expected_body))
       end)
 
-      assert BelayApiClient.fetch_market_stock_universe(client) == {:ok, expected_stock_universe}
+      assert BelayApiClient.fetch_market_stock_universe() == {:ok, expected_stock_universe}
     end
   end
 

--- a/test/integration/belay_api_client_test.exs
+++ b/test/integration/belay_api_client_test.exs
@@ -30,9 +30,7 @@ defmodule Integration.BelayApiClientTest do
     end
 
     test "fetch_market_clock" do
-      client = create_real_client()
-
-      assert {:ok, %{is_open: is_open, opens_in: opens_in}} = BelayApiClient.fetch_market_clock(client)
+      assert {:ok, %{is_open: is_open, opens_in: opens_in}} = BelayApiClient.fetch_market_clock()
 
       case is_open do
         true -> assert opens_in == 0

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -5,10 +5,7 @@ ExUnit.configure(assert_receive_timeout: :timer.minutes(1), timeout: :timer.minu
 is_smoke = :smoke in ExUnit.configuration()[:include]
 
 # Figure out if market is open
-client_id = Application.fetch_env!(:belay_api_client, :client_id)
-client_secret = Application.fetch_env!(:belay_api_client, :client_secret)
-{:ok, client} = BelayApiClient.client(client_id, client_secret)
-{:ok, %{is_open: is_market_open}} = BelayApiClient.fetch_market_clock(client)
+{:ok, %{is_open: is_market_open}} = BelayApiClient.fetch_market_clock()
 
 cond do
   is_smoke and is_market_open ->


### PR DESCRIPTION
Add a public_client/0 func that returns a public Tesla client for uses with our public endpoints like `/api/market/clock` or `/api/market/stock_universe`. Means we do not need to use a partner to grab a token to access these endpoints in our test_helpers